### PR TITLE
Create RESOURCES.md

### DIFF
--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -2,8 +2,8 @@
 
 ## Services
 
-* [Aggregation Service for Measurement](https://github.com/privacysandbox/aggregation-service)
-* [Bidding and Auction Servers](https://github.com/privacysandbox/bidding-auction-servers)
+* [Aggregation Service](https://github.com/privacysandbox/aggregation-service)
+* [Bidding and Auction Services](https://github.com/privacysandbox/bidding-auction-servers)
 * [Protected Audiences Key/Value Service](https://github.com/privacysandbox/fledge-key-value-service)
 
 ## Libraries
@@ -12,6 +12,6 @@
 
 ## Documentation
 
-* [Attribution Reporting API](https://github.com/WICG/attribution-reporting-api/tree/main)
-* [Protected Audiences](https://github.com/WICG/turtledove)
-* [Protected Auction Sercices](https://github.com/privacysandbox/protected-auction-services-docs)
+* [Attribution Reporting](https://github.com/WICG/attribution-reporting-api/tree/main)
+* [Protected Audience](https://github.com/WICG/turtledove)
+* [Protected Auction Services](https://github.com/privacysandbox/protected-auction-services-docs)

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,14 +1,17 @@
 # Resources
 
-## W3C groups
-
-* [Attribution Reporting API](https://github.com/WICG/attribution-reporting-api/tree/main)
-* [Protected Audiences](https://github.com/WICG/turtledove)
-
-## Github repositories
+## Services
 
 * [Aggregation Service for Measurement](https://github.com/privacysandbox/aggregation-service)
 * [Bidding and Auction Servers](https://github.com/privacysandbox/bidding-auction-servers)
 * [Protected Audiences Key/Value Service](https://github.com/privacysandbox/fledge-key-value-service)
-* [Data Plane Shared Libraries](https://github.com/privacysandbox/data-plane-shared-libraries) - shared libraries used by the three repositories above.
-* [Build System](https://github.com/privacysandbox/build-system) - shared libraries related to compiling Privacy Sandbox projects, used by all of the projects above.
+
+## Libraries
+* [Data Plane Shared Libraries](https://github.com/privacysandbox/data-plane-shared-libraries) - shared libraries used by all services.
+* [Build System](https://github.com/privacysandbox/build-system) - shared libraries related to compiling Privacy Sandbox projects, used by by all services.
+
+## Documentation
+
+* [Attribution Reporting API](https://github.com/WICG/attribution-reporting-api/tree/main)
+* [Protected Audiences](https://github.com/WICG/turtledove)
+* [Protected Auction Sercices](https://github.com/privacysandbox/protected-auction-services-docs)

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,0 +1,14 @@
+# Resources
+
+## W3C groups
+
+* [Attribution Reporting API](https://github.com/WICG/attribution-reporting-api/tree/main)
+* [Protected Audiences](https://github.com/WICG/turtledove)
+
+## Github repositories
+
+* [Aggregation Service for Measurement](https://github.com/privacysandbox/aggregation-service)
+* [Bidding and Auction Servers](https://github.com/privacysandbox/bidding-auction-servers)
+* [Protected Audiences Key/Value Service](https://github.com/privacysandbox/fledge-key-value-service)
+* [Data Plane Shared Libraries](https://github.com/privacysandbox/data-plane-shared-libraries) - shared libraries used by the three repositories above.
+* [Build System](https://github.com/privacysandbox/build-system) - shared libraries related to compiling Privacy Sandbox projects, used by all of the projects above.


### PR DESCRIPTION
In the first WICG call on Protected Auction Services there was a request to add a 'resources' doc that has a list of useful links.